### PR TITLE
29 node drag after background drag fix #29

### DIFF
--- a/src/components/results/drawGraphVisSlippyCanvas/dragEnded.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/dragEnded.js
@@ -1,0 +1,11 @@
+import * as d3 from 'd3';
+
+export default function dragEnded() {
+  // const { simulation } = props;
+  // if (!d3.event.active) simulation.alphaTarget(0);
+  // console.log('d3.event.subject from nodeDragEnded', d3.event.subject);
+  // uncomment to unpin nodes
+  // d3.event.subject.fx = null;
+  // d3.event.subject.fy = null;
+  d3.event.subject.active = false;
+}

--- a/src/components/results/drawGraphVisSlippyCanvas/dragStarted.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/dragStarted.js
@@ -1,0 +1,9 @@
+import * as d3 from 'd3';
+
+export default function nodeDragStarted(props) {
+  // const { simulation } = props;
+  // if (!d3.event.active) simulation.alphaTarget(0.3).restart();
+  // circles.splice(circles.indexOf(d3.event.subject), 1);
+  // circles.push(d3.event.subject);
+  d3.event.subject.active = true;
+}

--- a/src/components/results/drawGraphVisSlippyCanvas/dragSubject.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/dragSubject.js
@@ -1,18 +1,36 @@
 import * as d3 from 'd3';
 
-import findDataUnderMouse from './findDataUnderMouse';
-
 export default function dragSubject(props) {
-  const { transform, searchRadius, simulation } = props;
-  const x = transform.invertX(d3.event.x);
-  const y = transform.invertY(d3.event.y);
-  const m = [x, y];
-  const findDataUnderMouseProps = {
-    mousePosition: m,
-    simulation,
-    searchRadius,
-    transform
+  const { graph, radius, rects } = props;
+  let i;
+  const n = graph.nodes.length;
+  let dx;
+  let dy;
+  let d2;
+  let s2 = radius * radius * 4;
+  let node;
+  let subject;
+
+  for (i = 0; i < n; i += 1) {
+    node = graph.nodes[i];
+    // console.log('node from dragSubject', node);
+    dx = d3.event.x - node.x - rects[0].x;
+    dy = d3.event.y - node.y - rects[0].y;
+    d2 = dx * dx + dy * dy;
+
+    // console.log('dx', dx);
+    // console.log('dy', dy);
+    // console.log('d2', d2);
+    // console.log('s2', s2);
+
+    if (d2 < s2) {
+      subject = node;
+      s2 = d2;
+    } else if (typeof subject === 'undefined') {
+      let background = rects[0];
+      subject = background;
+      console.log('background', background);
+    }
   }
-  const d = findDataUnderMouse(findDataUnderMouseProps);
-  return d;
+  return subject;
 }

--- a/src/components/results/drawGraphVisSlippyCanvas/dragged.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/dragged.js
@@ -1,43 +1,6 @@
 import * as d3 from 'd3';
 
-import render from './render';
-import findDataUnderMouse from './findDataUnderMouse';
-
-export default function dragged(props) {
-  const {
-    context,
-    width,
-    height,
-    transform,
-    graph,
-    imageCache,
-    simulation,
-    searchRadius,
-    canvas
-  } = props;
-  const renderProps = {
-    context,
-    width,
-    height,
-    transform,
-    graph,
-    imageCache
-  };
-  const m = d3.mouse(canvas);
-  const findDataUnderMouseProps = {
-    mousePosition: m,
-    simulation,
-    searchRadius,
-    transform
-  };
-  const d = findDataUnderMouse(findDataUnderMouseProps);
-  if (typeof d !== 'undefined') {
-    d3.event.subject.fx = transform.invertX(d3.event.x);
-    d3.event.subject.fy = transform.invertY(d3.event.y);
-    render(renderProps);
-  } else {
-    d3.event.subject[0] = transform.invertX(d3.event.x);
-    d3.event.subject[1] = transform.invertY(d3.event.y);
-    render(renderProps);
-  }
+export default function dragged() {
+  d3.event.subject.x = d3.event.x;
+  d3.event.subject.y = d3.event.y;
 }

--- a/src/components/results/drawGraphVisSlippyCanvas/drawLink.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/drawLink.js
@@ -1,4 +1,19 @@
-export default function drawLink(context, d) {
-  context.moveTo(d.source.x, d.source.y);
-  context.lineTo(d.target.x, d.target.y);
+export default function drawLink(props, link) {
+  const { graph, context, rect } = props;
+  if (
+    typeof graph.nodes[link.source] !== 'undefined' &&
+    typeof graph.nodes[link.target] !== 'undefined'
+  ) {
+    // console.log('rect.x', rect.x);
+    // console.log('graph.nodes[link.source]', graph.nodes[link.source]);
+    // console.log('graph.nodes[link.source].x', graph.nodes[link.source].x);
+    context.moveTo(
+      graph.nodes[link.source].x + rect.x,
+      graph.nodes[link.source].y + rect.y
+    );
+    context.lineTo(
+      graph.nodes[link.target].x + rect.x,
+      graph.nodes[link.target].y + rect.y
+    );
+  }
 }

--- a/src/components/results/drawGraphVisSlippyCanvas/drawNode.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/drawNode.js
@@ -1,58 +1,55 @@
-export default function drawNode(context, imageCache, width, height, d) {
-    // old solid color nodes
-    // context.moveTo(d.x + 3, d.y);
-    // context.arc(d.x, d.y, 3, 0, 2 * Math.PI);
+export default function drawNode(props, d) {
+  const { rect, context, imageCache, radius } = props;
+  const image = imageCache[d.id];
+  const iconWidth = 92;
+  const iconHeight = 48;
+  // const radius = 22;
 
-    const image = imageCache[d.id];
-    const iconWidth = 92;
-    const iconHeight = 48;
-    const radius = 22;
+  // draw border to check intution
+  // context.strokeStyle = 'darkgray';
+  // context.strokeRect(-width / 2, -height / 2, width - 2, height - 2);
 
-    // draw border to check intution
-    // context.strokeStyle = 'darkgray';
-    // context.strokeRect(-width / 2, -height / 2, width - 2, height - 2);
+  const nX = d.x + rect.x;
+  const nY = d.y + rect.y;
 
-    const nX = d.x;
-    const nY = d.y;
+  // draw images with a circular clip mask
+  // so that rectangular thumbnail images become
+  // round node icons
+  if (typeof image !== 'undefined' && image.height > 0) {
+    context.save();
+    context.beginPath();
+    context.arc(nX, nY, radius, 0, Math.PI * 2, true);
+    context.closePath();
+    context.clip();
 
-    // draw images with a circular clip mask
-    // so that rectangular thumbnail images become
-    // round node icons
-    if (typeof image !== 'undefined' && image.height > 0) {
-      context.save();
-      context.beginPath();
-      context.arc(nX, nY, radius, 0, Math.PI * 2, true);
-      context.closePath();
-      context.clip();
+    context.drawImage(
+      image,
+      0,
+      0,
+      230,
+      120,
+      nX - iconWidth / 2,
+      nY - iconHeight / 2,
+      iconWidth,
+      iconHeight
+    );
 
-      context.drawImage(
-        image,
-        0,
-        0,
-        230,
-        120,
-        nX - iconWidth / 2,
-        nY - iconHeight / 2,
-        iconWidth,
-        iconHeight
-      );
+    context.beginPath();
+    context.arc(0, 0, 2, 0, Math.PI * 2, true);
+    context.clip();
+    context.closePath();
+    context.restore();
+  } else {
+    // gray from the blockbuilder search results page
+    context.fillStyle = '#EEEEEE';
+    context.beginPath();
+    context.arc(nX, nY, radius, 0, Math.PI * 2, true);
+    context.closePath();
+    context.fill();
 
-      context.beginPath();
-      context.arc(0, 0, 2, 0, Math.PI * 2, true);
-      context.clip();
-      context.closePath();
-      context.restore();
-    } else {
-      // gray from the blockbuilder search results page
-      context.fillStyle = '#EEEEEE';
-      context.beginPath();
-      context.arc(nX, nY, radius, 0, Math.PI * 2, true);
-      context.closePath();
-      context.fill();
-
-      // teal from blockbuilder search results page
-      context.fillStyle = '#66B5B4';
-      context.font = '20px Georgia';
-      context.fillText('?', nX - 5, nY + 8);
-    }
+    // teal from blockbuilder search results page
+    context.fillStyle = '#66B5B4';
+    context.font = '20px Georgia';
+    context.fillText('?', nX - 5, nY + 8);
   }
+}

--- a/src/components/results/drawGraphVisSlippyCanvas/nodeDragEnded.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/nodeDragEnded.js
@@ -1,9 +1,0 @@
-import * as d3 from 'd3';
-
-export default function dragended(props) {
-  const { simulation } = props;
-  if (!d3.event.active) simulation.alphaTarget(0);
-  // uncomment to unpin nodes
-  // d3.event.subject.fx = null;
-  // d3.event.subject.fy = null;
-}

--- a/src/components/results/drawGraphVisSlippyCanvas/nodeDragStarted.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/nodeDragStarted.js
@@ -1,8 +1,0 @@
-import * as d3 from 'd3';
-
-export default function nodeDragStarted(props) {
-  const { simulation } = props;
-  if (!d3.event.active) simulation.alphaTarget(0.3).restart();
-  d3.event.subject.fx = d3.event.subject.x;
-  d3.event.subject.fy = d3.event.subject.y;
-}

--- a/src/components/results/drawGraphVisSlippyCanvas/nodeDragged.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/nodeDragged.js
@@ -1,6 +1,0 @@
-import * as d3 from 'd3';
-
-export default function dragged() {
-  d3.event.subject.fx = d3.event.x;
-  d3.event.subject.fy = d3.event.y;
-}

--- a/src/components/results/drawGraphVisSlippyCanvas/onClick.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/onClick.js
@@ -1,17 +1,10 @@
-import * as d3 from 'd3';
-
-import findDataUnderMouse from './findDataUnderMouse';
+import dragSubject from './dragSubject';
 
 export default function onClick(props) {
-  const { simulation, searchRadius, canvas, transform } = props;
-  const m = d3.mouse(canvas);
-  const findDataUnderMouseProps = {
-    mousePosition: m,
-    simulation,
-    searchRadius,
-    transform
-  };
-  const d = findDataUnderMouse(findDataUnderMouseProps);
+  const { graph, radius, rects } = props;
+  const dragSubjectProps = { graph, radius, rects };
+  const d = dragSubject(dragSubjectProps);
+
   if (typeof d !== 'undefined') {
     const blockUrl = `http://bl.ocks.org/${d.user ? `${d.user}/` : ''}${d.id}`;
     window.open(blockUrl);

--- a/src/components/results/drawGraphVisSlippyCanvas/render.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/render.js
@@ -1,23 +1,28 @@
-import drawLink from './drawLink';
+// import drawLink from './drawLink';
 import drawNode from './drawNode';
 
 export default function render(props) {
   const { context, width, height, graph, imageCache, rects, radius } = props;
-
-  context.save();
   context.clearRect(0, 0, width, height);
   // draw the invisible background
   rects.forEach(rect => {
     context.clearRect(0, 0, width, height);
 
     // draw the links
-    context.strokeStyle = '#aaa';
-    context.lineWidth = 1;
-    context.beginPath();
-
-    const drawLinkProps = { graph, context, rect };
-    graph.links.forEach(drawLink.bind(this, drawLinkProps));
-    context.stroke();
+      context.strokeStyle = '#aaa';
+      context.lineWidth = 1;
+      context.beginPath();
+      graph.links.forEach(link => {
+        context.moveTo(
+          graph.nodes[link.source.index].x + rect.x,
+          graph.nodes[link.source.index].y + rect.y
+        );
+        context.lineTo(
+          graph.nodes[link.target.index].x + rect.x,
+          graph.nodes[link.target.index].y + rect.y
+        );
+      });
+      context.stroke();;
 
     // draw the nodes
     context.beginPath();
@@ -30,6 +35,4 @@ export default function render(props) {
     graph.nodes.forEach(drawNode.bind(this, drawNodeProps));
     context.fill();
   });
-
-  context.restore();
 }

--- a/src/components/results/drawGraphVisSlippyCanvas/render.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/render.js
@@ -2,22 +2,33 @@ import drawLink from './drawLink';
 import drawNode from './drawNode';
 
 export default function render(props) {
-  const { context, width, height, transform, graph, imageCache } = props;
+  const { context, width, height, graph, imageCache, rects, radius } = props;
+
   context.save();
   context.clearRect(0, 0, width, height);
-  context.beginPath();
-  context.translate(transform.x, transform.y);
-  context.scale(transform.k, transform.k);
+  // draw the invisible background
+  rects.forEach(rect => {
+    context.clearRect(0, 0, width, height);
 
-  // draw links
-  graph.links.forEach(drawLink.bind(this, context));
-  context.strokeStyle = '#aaa';
-  context.stroke();
-
-  // draw nodes
-  graph.nodes.forEach(node => {
+    // draw the links
+    context.strokeStyle = '#aaa';
+    context.lineWidth = 1;
     context.beginPath();
-    drawNode(context, imageCache, width, height, node);
+
+    const drawLinkProps = { graph, context, rect };
+    graph.links.forEach(drawLink.bind(this, drawLinkProps));
+    context.stroke();
+
+    // draw the nodes
+    context.beginPath();
+    const drawNodeProps = {
+      rect,
+      context,
+      imageCache,
+      radius
+    };
+    graph.nodes.forEach(drawNode.bind(this, drawNodeProps));
+    context.fill();
   });
 
   context.restore();


### PR DESCRIPTION
This PR adds a neo4j style canvas UI that allows the user to drag both the background as well as individual nodes.

![29-node-drag-after-background-drag](https://user-images.githubusercontent.com/2119400/30302556-9fac217e-9716-11e7-86f2-8a7d65a8dfed.gif)
