### PR TITLE
53 show node no relationships fix #53

### DIFF
--- a/src/components/results/cacheImages.js
+++ b/src/components/results/cacheImages.js
@@ -2,9 +2,7 @@ export default function cacheImages(graph, imageCache) {
   graph.nodes.forEach(d => {
     const image = new Image();
 
-    image.src = `https://bl.ocks.org/${d.user
-      ? `${d.user}/`
-      : ''}raw/${d.id}/thumbnail.png`;
+    image.src = `https://gist.githubusercontent.com/raw/${d.id}/thumbnail.png`;
     imageCache[d.id] = image;
   });
 }

--- a/src/components/results/drawGraphVisSlippyCanvas/drawGraphVisSlippyCanvas.js
+++ b/src/components/results/drawGraphVisSlippyCanvas/drawGraphVisSlippyCanvas.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import cloneDeep from 'lodash.clonedeep';
 
-import jLouvain from '../../../lib/jsLouvain';
+// import jLouvain from '../../../lib/jsLouvain';
 
 import render from './render';
 import cacheImages from '../cacheImages';
@@ -55,21 +55,22 @@ export default function drawGraphVisSlippyCanvas(inputGraph) {
   //
   // detect communities with jsLouvain
   //
-  const nodeData = graph.nodes.map(function(d) {
-    return d.id;
-  });
-  const linkData = graph.links.map(function(d) {
-    return { source: d.source, target: d.target, weight: d.weight };
-  });
+  // const nodeData = graph.nodes.map(function(d) {
+  //   return d.id;
+  // });
+  // const linkData = graph.links.map(function(d) {
+  //   return { source: d.source, target: d.target, weight: d.weight };
+  // });
 
-  const community = jLouvain()
-    .nodes(nodeData)
-    .edges(linkData);
-  const result = community();
+
+  // const community = jLouvain()
+  //   .nodes(nodeData)
+  //   .edges(linkData);
+  // const result = community();
 
   const nodeIndexHash = {};
   graph.nodes.forEach(function(node, i) {
-    node.group = result[node.id];
+    // node.group = result[node.id];
     node.r = radius;
     nodeIndexHash[node.id] = i;
   });

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -57,7 +57,21 @@ export default function rootReducer(state = initialState, action) {
     // onto our graph object
     Object.keys(linkHash).forEach(key => {
       graph.links.push(linkHash[key]);
-    })
+    });
+
+    // if the graph is empty
+    // and the query string contains a gist_id
+    // populate the graph with one node
+    // for that gist_id, that block
+    if (graph.nodes.length === 0) {
+      const paramsString = window.location.search;
+      const searchParams = new URLSearchParams(paramsString);
+      const gistId = searchParams.get('gist_id');
+      graph.nodes.push({
+        id: gistId
+      })
+    }
+
     return graph;
   }
   switch (action.type) {


### PR DESCRIPTION
This PR ensures that a node is drawn if a gist_id is specified in the query string but the neo4j query does not return any nodes or relationships.  

This gives a better user experience so that when a user clicks on a graph-search in blockbuilder search, they at least see that source block in the graph search view.

![screen shot 2017-09-21 at 1 46 52 pm](https://user-images.githubusercontent.com/2119400/30718139-dc64205c-9ed3-11e7-9ed3-0967d08c06d5.png)

issue #53 